### PR TITLE
Add topology for cometlake

### DIFF
--- a/tools/topology/CMakeLists.txt
+++ b/tools/topology/CMakeLists.txt
@@ -58,6 +58,7 @@ set(TPLGS
 	"sof-apl-dmic\;sof-apl-dmic-2ch\;-DCHANNELS=2"
 	"sof-icl-dmic-4ch\;sof-icl-dmic-4ch"
 	"sof-icl-rt700\;sof-icl-rt700\;-DPLATFORM=icl"
+	"sof-cml-rt700\;sof-cml-rt700\;-DPLATFORM=cml"
 	"sof-apl-src-pcm512x\;sof-apl-src-pcm512x"
 	"sof-cml-rt5682\;sof-cml-rt5682\;-DPLATFORM=cml"
 	"sof-cml-rt5682\;sof-whl-rt5682\;-DPLATFORM=whl"

--- a/tools/topology/sof-cml-rt700.m4
+++ b/tools/topology/sof-cml-rt700.m4
@@ -1,0 +1,125 @@
+#
+# Topology for Cometlake with rt700 codec.
+#
+
+# Include topology builder
+include(`utils.m4')
+include(`dai.m4')
+include(`pipeline.m4')
+
+# Include TLV library
+include(`common/tlv.m4')
+
+# Include Token library
+include(`sof/tokens.m4')
+
+# Include CML DSP configuration
+include(`platform/intel/cnl.m4')
+include(`platform/intel/dmic.m4')
+
+DEBUG_START
+
+#
+# Define the pipelines
+#
+# PCM0 ---> volume ----> ALH 2 BE dailink 0
+# PCM1 <--- volume <---- ALH 3 BE dailink 1
+# PCM2 <---------------- DMIC01 (dmic0 capture, BE dailink 2)
+# PCM3 <---------------- DMIC16k (dmic16k, BE dailink 3)
+
+dnl PIPELINE_PCM_ADD(pipeline,
+dnl     pipe id, pcm, max channels, format,
+dnl     frames, deadline, priority, core)
+
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
+	1, 0, 2, s32le,
+	48, 1000, 0, 0)
+
+# Low Latency capture pipeline 2 on PCM 0 using max 2 channels of s32le.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
+	2, 0, 2, s32le,
+	48, 1000, 0, 0)
+
+# Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
+# Schedule 48 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	3, 2, 4, s32le,
+	48, 1000, 0, 0)
+
+# Passthrough capture pipeline 4 on PCM 3 using max 2 channels.
+# Schedule 16 frames per 1000us deadline on core 0 with priority 0
+PIPELINE_PCM_ADD(sof/pipe-passthrough-capture.m4,
+	4, 3, 2, s16le,
+	16, 1000, 0, 0)
+
+#
+# DAIs configuration
+#
+
+dnl DAI_ADD(pipeline,
+dnl     pipe id, dai type, dai_index, dai_be,
+dnl     buffer, periods, format,
+dnl     frames, deadline, priority, core)
+
+# playback DAI is ALH(SDW1 PIN2) using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-playback.m4,
+	1, ALH, 0x102, SDW1-Playback,
+	PIPELINE_SOURCE_1, 2, s32le,
+	48, 1000, 0, 0)
+
+# capture DAI is ALH(SDW1 PIN3) using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	2, ALH, 0x103, SDW1-Capture,
+	PIPELINE_SINK_2, 2, s32le,
+	48, 1000, 0, 0)
+
+# capture DAI is DMIC01 using 2 periods
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	3, DMIC, 0, dmic01,
+	PIPELINE_SINK_3, 2, s32le,
+	48, 1000, 0, 0)
+
+# capture DAI is DMIC16k using 2 periods
+# Buffers use s16le format, with 16 frame per 1000us on core 0 with priority 0
+DAI_ADD(sof/pipe-dai-capture.m4,
+	4, DMIC, 1, dmic16k,
+	PIPELINE_SINK_4, 2, s16le,
+	16, 1000, 0, 0)
+
+# PCM Low Latency, id 0
+dnl PCM_PLAYBACK_ADD(name, pcm_id, playback)
+PCM_PLAYBACK_ADD(SDW1-speakers, 0, PIPELINE_PCM_1)
+PCM_CAPTURE_ADD(SDW1-mics, 1, PIPELINE_PCM_2)
+PCM_CAPTURE_ADD(DMIC01, 2, PIPELINE_PCM_3)
+PCM_CAPTURE_ADD(DMIC16k, 3, PIPELINE_PCM_4)
+
+#
+# BE configurations - overrides config in ACPI if present
+#
+
+#ALH dai index = ((link_id << 8) | PDI id)
+#ALH SDW1 Pin2 (ID: 0)
+DAI_CONFIG(ALH, 0x102, 0, SDW1-Playback)
+
+#ALH SDW1 Pin3 (ID: 1)
+DAI_CONFIG(ALH, 0x103, 1, SDW1-Capture)
+
+# dmic01 (ID: 1)
+DAI_CONFIG(DMIC, 0, 2, dmic01,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 48000,
+		DMIC_WORD_LENGTH(s32le), 400, DMIC, 0,
+		PDM_CONFIG(DMIC, 0, FOUR_CH_PDM0_PDM1)))
+
+# dmic16k (ID: 2)
+DAI_CONFIG(DMIC, 1, 3, dmic16k,
+	   DMIC_CONFIG(1, 500000, 4800000, 40, 60, 16000,
+		DMIC_WORD_LENGTH(s16le), 400, DMIC, 1,
+		PDM_CONFIG(DMIC, 1, STEREO_PDM0)))
+
+DEBUG_END

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -1,5 +1,5 @@
 #
-# Topology for Cometlake with rt5682 codec.
+# Topology for Icelake with rt700 codec.
 #
 
 # Include topology builder
@@ -25,8 +25,8 @@ DEBUG_START
 #
 # PCM0 ---> volume ----> ALH 2 BE dailink 0
 # PCM1 <--- volume <---- ALH 3 BE dailink 1
-# PCM2 <------------------ DMIC01 (dmic0 capture, , BE link 2)
-# PCM3 <------------------ DMIC16k (dmic16k, BE link 3)
+# PCM2 <---------------- DMIC01 (dmic0 capture, BE dailink 2)
+# PCM3 <---------------- DMIC16k (dmic16k, BE dailink 3)
 #
 
 dnl PIPELINE_PCM_ADD(pipeline,
@@ -106,6 +106,7 @@ PCM_CAPTURE_ADD(DMIC16k, 3, PIPELINE_PCM_4)
 # BE configurations - overrides config in ACPI if present
 #
 
+#ALH dai index = ((link_id << 8) | PDI id)
 #ALH SDW0 Pin2 (ID: 0)
 DAI_CONFIG(ALH, 2, 0, SDW0-Playback)
 

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -6,7 +6,7 @@
 include(`utils.m4')
 include(`dai.m4')
 include(`pipeline.m4')
-include(`alh.m4')
+#include(`alh.m4')
 
 # Include TLV library
 include(`common/tlv.m4')

--- a/tools/topology/sof-icl-rt700.m4
+++ b/tools/topology/sof-icl-rt700.m4
@@ -33,16 +33,16 @@ dnl PIPELINE_PCM_ADD(pipeline,
 dnl     pipe id, pcm, max channels, format,
 dnl     frames, deadline, priority, core)
 
-# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s24le.
+# Low Latency playback pipeline 1 on PCM 0 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-playback.m4,
-	1, 0, 2, s24le,
+	1, 0, 2, s32le,
 	48, 1000, 0, 0)
 
-# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s24le.
+# Low Latency capture pipeline 2 on PCM 1 using max 2 channels of s32le.
 # Schedule 48 frames per 1000us deadline on core 0 with priority 0
 PIPELINE_PCM_ADD(sof/pipe-volume-capture.m4,
-	2, 1, 2, s24le,
+	2, 1, 2, s32le,
 	48, 1000, 0, 0)
 
 # Passthrough capture pipeline 3 on PCM 2 using max 4 channels.
@@ -67,17 +67,17 @@ dnl     buffer, periods, format,
 dnl     frames, deadline, priority, core)
 
 # playback DAI is ALH(SDW0 PIN2) using 2 periods
-# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-playback.m4,
 	1, ALH, 2, SDW0-Playback,
-	PIPELINE_SOURCE_1, 2, s24le,
+	PIPELINE_SOURCE_1, 2, s32le,
 	48, 1000, 0, 0)
 
 # capture DAI is ALH(SDW0 PIN2) using 2 periods
-# Buffers use s24le format, with 48 frame per 1000us on core 0 with priority 0
+# Buffers use s32le format, with 48 frame per 1000us on core 0 with priority 0
 DAI_ADD(sof/pipe-dai-capture.m4,
 	2, ALH, 3, SDW0-Capture,
-	PIPELINE_SINK_2, 2, s24le,
+	PIPELINE_SINK_2, 2, s32le,
 	48, 1000, 0, 0)
 
 # capture DAI is DMIC01 using 2 periods


### PR DESCRIPTION
(1)  RT700 is connected to sdw header1 on CometLake platform
    instead of head0 on IceLake platform, so these two platforms
    can't share the same topology file.

(2) fix compiling error for icl